### PR TITLE
Setup meeting assistant workspace

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.png filter=lfs diff=lfs merge=lfs -text
+*.ico filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore build artifacts
+node_modules/
+dist/
+.next/
+out/
+build/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+cd meeting-assistant && npx nx run-many --target=lint,test --all

--- a/meeting-assistant/.env.development
+++ b/meeting-assistant/.env.development
@@ -1,0 +1,1 @@
+DATABASE_URL=postgres://dev:devpass@localhost:5432/meetingdb

--- a/meeting-assistant/.gitignore
+++ b/meeting-assistant/.gitignore
@@ -1,0 +1,49 @@
+# See https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files for more about ignoring files.
+
+# compiled output
+dist
+tmp
+out-tsc
+
+# dependencies
+node_modules
+package-lock.json
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# misc
+/.sass-cache
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log
+yarn-error.log
+testem.log
+/typings
+
+# System Files
+.DS_Store
+Thumbs.db
+
+.nx/cache
+.nx/workspace-data
+.cursor/rules/nx-rules.mdc
+.github/instructions/nx.instructions.md
+
+vite.config.*.timestamp*
+vitest.config.*.timestamp*
+test-output

--- a/meeting-assistant/.prettierignore
+++ b/meeting-assistant/.prettierignore
@@ -1,0 +1,5 @@
+# Add files here to ignore them from prettier formatting
+/dist
+/coverage
+/.nx/cache
+/.nx/workspace-data

--- a/meeting-assistant/.prettierrc
+++ b/meeting-assistant/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/meeting-assistant/.vscode/extensions.json
+++ b/meeting-assistant/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "nrwl.angular-console",
+    "esbenp.prettier-vscode",
+    "ms-playwright.playwright"
+  ]
+}

--- a/meeting-assistant/README.md
+++ b/meeting-assistant/README.md
@@ -1,0 +1,109 @@
+# MeetingAssistant
+
+<a alt="Nx logo" href="https://nx.dev" target="_blank" rel="noreferrer"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-logo.png" width="45"></a>
+
+✨ Your new, shiny [Nx workspace](https://nx.dev) is ready ✨.
+
+[Learn more about this workspace setup and its capabilities](https://nx.dev/nx-api/js?utm_source=nx_project&amp;utm_medium=readme&amp;utm_campaign=nx_projects) or run `npx nx graph` to visually explore what was created. Now, let's get you up to speed!
+
+## Generate a library
+
+```sh
+npx nx g @nx/js:lib packages/pkg1 --publishable --importPath=@my-org/pkg1
+```
+
+## Run tasks
+
+To build the library use:
+
+```sh
+npx nx build pkg1
+```
+
+To run any task with Nx use:
+
+```sh
+npx nx <target> <project-name>
+```
+
+These targets are either [inferred automatically](https://nx.dev/concepts/inferred-tasks?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects) or defined in the `project.json` or `package.json` files.
+
+[More about running tasks in the docs &raquo;](https://nx.dev/features/run-tasks?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+
+## Versioning and releasing
+
+To version and release the library use
+
+```
+npx nx release
+```
+
+Pass `--dry-run` to see what would happen without actually releasing the library.
+
+[Learn more about Nx release &raquo;](https://nx.dev/features/manage-releases?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+
+## Keep TypeScript project references up to date
+
+Nx automatically updates TypeScript [project references](https://www.typescriptlang.org/docs/handbook/project-references.html) in `tsconfig.json` files to ensure they remain accurate based on your project dependencies (`import` or `require` statements). This sync is automatically done when running tasks such as `build` or `typecheck`, which require updated references to function correctly.
+
+To manually trigger the process to sync the project graph dependencies information to the TypeScript project references, run the following command:
+
+```sh
+npx nx sync
+```
+
+You can enforce that the TypeScript project references are always in the correct state when running in CI by adding a step to your CI job configuration that runs the following command:
+
+```sh
+npx nx sync:check
+```
+
+[Learn more about nx sync](https://nx.dev/reference/nx-commands#sync)
+
+## Set up CI!
+
+### Step 1
+
+To connect to Nx Cloud, run the following command:
+
+```sh
+npx nx connect
+```
+
+Connecting to Nx Cloud ensures a [fast and scalable CI](https://nx.dev/ci/intro/why-nx-cloud?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects) pipeline. It includes features such as:
+
+- [Remote caching](https://nx.dev/ci/features/remote-cache?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+- [Task distribution across multiple machines](https://nx.dev/ci/features/distribute-task-execution?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+- [Automated e2e test splitting](https://nx.dev/ci/features/split-e2e-tasks?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+- [Task flakiness detection and rerunning](https://nx.dev/ci/features/flaky-tasks?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+
+### Step 2
+
+Use the following command to configure a CI workflow for your workspace:
+
+```sh
+npx nx g ci-workflow
+```
+
+[Learn more about Nx on CI](https://nx.dev/ci/intro/ci-with-nx#ready-get-started-with-your-provider?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+
+## Install Nx Console
+
+Nx Console is an editor extension that enriches your developer experience. It lets you run tasks, generate code, and improves code autocompletion in your IDE. It is available for VSCode and IntelliJ.
+
+[Install Nx Console &raquo;](https://nx.dev/getting-started/editor-setup?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+
+## Useful links
+
+Learn more:
+
+- [Learn more about this workspace setup](https://nx.dev/nx-api/js?utm_source=nx_project&amp;utm_medium=readme&amp;utm_campaign=nx_projects)
+- [Learn about Nx on CI](https://nx.dev/ci/intro/ci-with-nx?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+- [Releasing Packages with Nx release](https://nx.dev/features/manage-releases?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+- [What are Nx plugins?](https://nx.dev/concepts/nx-plugins?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+
+And join the Nx community:
+- [Discord](https://go.nx.dev/community)
+- [Follow us on X](https://twitter.com/nxdevtools) or [LinkedIn](https://www.linkedin.com/company/nrwl)
+- [Our Youtube channel](https://www.youtube.com/@nxdevtools)
+- [Our blog](https://nx.dev/blog?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)

--- a/meeting-assistant/apps/api-gateway-e2e/.spec.swcrc
+++ b/meeting-assistant/apps/api-gateway-e2e/.spec.swcrc
@@ -1,0 +1,22 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    },
+    "keepClassNames": true,
+    "externalHelpers": true,
+    "loose": true
+  },
+  "module": {
+    "type": "es6"
+  },
+  "sourceMaps": true,
+  "exclude": []
+}

--- a/meeting-assistant/apps/api-gateway-e2e/jest.config.ts
+++ b/meeting-assistant/apps/api-gateway-e2e/jest.config.ts
@@ -1,0 +1,24 @@
+/* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config for the spec files
+const swcJestConfig = JSON.parse(
+  readFileSync(`${__dirname}/.spec.swcrc`, 'utf-8')
+);
+
+// Disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves
+swcJestConfig.swcrc = false;
+
+export default {
+  displayName: '@meeting-assistant/api-gateway-e2e',
+  preset: '../jest.preset.js',
+  globalSetup: '<rootDir>/src/support/global-setup.ts',
+  globalTeardown: '<rootDir>/src/support/global-teardown.ts',
+  setupFiles: ['<rootDir>/src/support/test-setup.ts'],
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: 'test-output/jest/coverage',
+};

--- a/meeting-assistant/apps/api-gateway-e2e/package.json
+++ b/meeting-assistant/apps/api-gateway-e2e/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@meeting-assistant/api-gateway-e2e",
+  "version": "0.0.1",
+  "private": true,
+  "nx": {
+    "implicitDependencies": [
+      "@meeting-assistant/api-gateway"
+    ],
+    "targets": {
+      "e2e": {
+        "executor": "@nx/jest:jest",
+        "outputs": [
+          "{projectRoot}/test-output/jest/coverage"
+        ],
+        "options": {
+          "jestConfig": "api-gateway-e2e/jest.config.ts",
+          "passWithNoTests": true
+        },
+        "dependsOn": [
+          "@meeting-assistant/api-gateway:build",
+          "@meeting-assistant/api-gateway:serve"
+        ]
+      }
+    }
+  }
+}

--- a/meeting-assistant/apps/api-gateway-e2e/src/api-gateway/api-gateway.spec.ts
+++ b/meeting-assistant/apps/api-gateway-e2e/src/api-gateway/api-gateway.spec.ts
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+describe('GET /api', () => {
+  it('should return a message', async () => {
+    try {
+      const res = await axios.get(`/api`);
+
+      expect(res.status).toBe(200);
+      expect(res.data).toEqual({ message: 'Hello API' });
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  });
+});

--- a/meeting-assistant/apps/api-gateway-e2e/src/support/global-setup.ts
+++ b/meeting-assistant/apps/api-gateway-e2e/src/support/global-setup.ts
@@ -1,0 +1,21 @@
+import { waitForPortOpen } from '@nx/node/utils';
+
+/* eslint-disable */
+var __TEARDOWN_MESSAGE__: string;
+
+module.exports = async function () {
+  try {
+    // Start services that that the app needs to run (e.g. database, docker-compose, etc.).
+    console.log('\nSetting up...\n');
+
+    const host = process.env.HOST ?? 'localhost';
+    const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+    await waitForPortOpen(port, { host });
+
+    // Hint: Use `globalThis` to pass variables to global teardown.
+    globalThis.__TEARDOWN_MESSAGE__ = '\nTearing down...\n';
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/meeting-assistant/apps/api-gateway-e2e/src/support/global-teardown.ts
+++ b/meeting-assistant/apps/api-gateway-e2e/src/support/global-teardown.ts
@@ -1,0 +1,15 @@
+import { killPort } from '@nx/node/utils';
+/* eslint-disable */
+
+module.exports = async function () {
+  try {
+    // Put clean up logic here (e.g. stopping services, docker-compose, etc.).
+    // Hint: `globalThis` is shared between setup and teardown.
+    const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+    await killPort(port);
+    console.log(globalThis.__TEARDOWN_MESSAGE__);
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/meeting-assistant/apps/api-gateway-e2e/src/support/test-setup.ts
+++ b/meeting-assistant/apps/api-gateway-e2e/src/support/test-setup.ts
@@ -1,0 +1,14 @@
+/* eslint-disable */
+import axios from 'axios';
+
+module.exports = async function () {
+  try {
+    // Configure axios for tests to use.
+    const host = process.env.HOST ?? 'localhost';
+    const port = process.env.PORT ?? '3000';
+    axios.defaults.baseURL = `http://${host}:${port}`;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/meeting-assistant/apps/api-gateway-e2e/tsconfig.json
+++ b/meeting-assistant/apps/api-gateway-e2e/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "out-tsc/@meeting-assistant/api-gateway-e2e",
+    "esModuleInterop": true,
+    "noUnusedLocals": false,
+    "noImplicitAny": false
+  },
+  "include": ["jest.config.ts", "src/**/*.ts"],
+  "references": []
+}

--- a/meeting-assistant/apps/api-gateway/package.json
+++ b/meeting-assistant/apps/api-gateway/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@meeting-assistant/api-gateway",
+  "version": "0.0.1",
+  "private": true,
+  "nx": {
+    "targets": {
+      "build": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "webpack-cli build",
+          "args": [
+            "--node-env=production"
+          ]
+        },
+        "configurations": {
+          "development": {
+            "args": [
+              "--node-env=development"
+            ]
+          }
+        }
+      },
+      "serve": {
+        "continuous": true,
+        "executor": "@nx/js:node",
+        "defaultConfiguration": "development",
+        "dependsOn": [
+          "build"
+        ],
+        "options": {
+          "buildTarget": "@meeting-assistant/api-gateway:build",
+          "runBuildTargetDependencies": false
+        },
+        "configurations": {
+          "development": {
+            "buildTarget": "@meeting-assistant/api-gateway:build:development"
+          },
+          "production": {
+            "buildTarget": "@meeting-assistant/api-gateway:build:production"
+          }
+        }
+      }
+    }
+  }
+}

--- a/meeting-assistant/apps/api-gateway/src/app/app.controller.ts
+++ b/meeting-assistant/apps/api-gateway/src/app/app.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller()
+export class AppController {
+  @Get('healthz')
+  health() {
+    return { ok: true };
+  }
+}

--- a/meeting-assistant/apps/api-gateway/src/app/app.module.ts
+++ b/meeting-assistant/apps/api-gateway/src/app/app.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Meeting } from '@shared/types';
+import { AppController } from './app.controller';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      url: process.env.DATABASE_URL,
+      entities: [Meeting],
+      synchronize: true,
+    }),
+    TypeOrmModule.forFeature([Meeting]),
+  ],
+  controllers: [AppController],
+  providers: [],
+})
+export class AppModule {}

--- a/meeting-assistant/apps/api-gateway/src/main.ts
+++ b/meeting-assistant/apps/api-gateway/src/main.ts
@@ -1,0 +1,26 @@
+/**
+ * This is not a production server yet!
+ * This is only a minimal backend to get started.
+ */
+
+import { Logger } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app/app.module';
+
+async function bootstrap() {
+  try {
+    const app = await NestFactory.create(AppModule);
+    const globalPrefix = 'api';
+    app.setGlobalPrefix(globalPrefix);
+    const port = process.env.PORT || 3000;
+    await app.listen(port);
+    Logger.log(
+      `🚀 Application is running on: http://localhost:${port}/${globalPrefix}`
+    );
+  } catch (err) {
+    Logger.error(err);
+    process.exit(1);
+  }
+}
+
+bootstrap();

--- a/meeting-assistant/apps/api-gateway/tsconfig.app.json
+++ b/meeting-assistant/apps/api-gateway/tsconfig.app.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["node"],
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/tsconfig.app.tsbuildinfo",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "target": "es2021"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [],
+  "references": [
+    {
+      "path": "../../libs/shared-types/tsconfig.lib.json"
+    }
+  ]
+}

--- a/meeting-assistant/apps/api-gateway/tsconfig.json
+++ b/meeting-assistant/apps/api-gateway/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "../../libs/shared-types"
+    },
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
+}

--- a/meeting-assistant/apps/api-gateway/webpack.config.js
+++ b/meeting-assistant/apps/api-gateway/webpack.config.js
@@ -1,0 +1,20 @@
+const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
+const { join } = require('path');
+
+module.exports = {
+  output: {
+    path: join(__dirname, 'dist'),
+  },
+  plugins: [
+    new NxAppWebpackPlugin({
+      target: 'node',
+      compiler: 'tsc',
+      main: './src/main.ts',
+      tsConfig: './tsconfig.app.json',
+      assets: ['./src/assets'],
+      optimization: false,
+      outputHashing: 'none',
+      generatePackageJson: true,
+    }),
+  ],
+};

--- a/meeting-assistant/apps/web-frontend-e2e/package.json
+++ b/meeting-assistant/apps/web-frontend-e2e/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@meeting-assistant/web-frontend-e2e",
+  "version": "0.0.1",
+  "private": true,
+  "nx": {
+    "implicitDependencies": [
+      "@meeting-assistant/web-frontend"
+    ]
+  }
+}

--- a/meeting-assistant/apps/web-frontend-e2e/playwright.config.ts
+++ b/meeting-assistant/apps/web-frontend-e2e/playwright.config.ts
@@ -1,0 +1,68 @@
+import { defineConfig, devices } from '@playwright/test';
+import { nxE2EPreset } from '@nx/playwright/preset';
+import { workspaceRoot } from '@nx/devkit';
+
+// For CI, you may want to set BASE_URL to the deployed application.
+const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  ...nxE2EPreset(__filename, { testDir: './src' }),
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    baseURL,
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npx nx run @meeting-assistant/web-frontend:preview',
+    url: 'http://localhost:4200',
+    reuseExistingServer: true,
+    cwd: workspaceRoot,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    // Uncomment for mobile browsers support
+    /* {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 12'] },
+    }, */
+
+    // Uncomment for branded browsers
+    /* {
+      name: 'Microsoft Edge',
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    },
+    {
+      name: 'Google Chrome',
+      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    } */
+  ],
+});

--- a/meeting-assistant/apps/web-frontend-e2e/src/example.spec.ts
+++ b/meeting-assistant/apps/web-frontend-e2e/src/example.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('has title', async ({ page }) => {
+  try {
+    await page.goto('/');
+
+    // Expect h1 to contain a substring.
+    expect(await page.locator('h1').innerText()).toContain('Welcome');
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+});

--- a/meeting-assistant/apps/web-frontend-e2e/tsconfig.json
+++ b/meeting-assistant/apps/web-frontend-e2e/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "outDir": "out-tsc/playwright",
+    "sourceMap": false
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.js",
+    "playwright.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.js",
+    "src/**/*.test.ts",
+    "src/**/*.test.js",
+    "src/**/*.d.ts"
+  ],
+  "exclude": ["out-tsc", "test-output"]
+}

--- a/meeting-assistant/apps/web-frontend/index.html
+++ b/meeting-assistant/apps/web-frontend/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>WebFrontend</title>
+    <base href="/" />
+
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="stylesheet" href="/src/styles.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/meeting-assistant/apps/web-frontend/package.json
+++ b/meeting-assistant/apps/web-frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@meeting-assistant/web-frontend",
+  "version": "0.0.1",
+  "private": true,
+  "devDependencies": {
+    "@tailwindcss/cli": "^4.1.11",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^3.4.1"
+  },
+  "dependencies": {
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^3.3.1"
+  }
+}

--- a/meeting-assistant/apps/web-frontend/postcss.config.js
+++ b/meeting-assistant/apps/web-frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/meeting-assistant/apps/web-frontend/src/app/app.module.css
+++ b/meeting-assistant/apps/web-frontend/src/app/app.module.css
@@ -1,0 +1,1 @@
+/* Your styles goes here. */

--- a/meeting-assistant/apps/web-frontend/src/app/app.tsx
+++ b/meeting-assistant/apps/web-frontend/src/app/app.tsx
@@ -1,0 +1,16 @@
+import { Card, CardContent } from "@/components/ui/card";
+
+export default function App() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100 p-4">
+      <Card className="w-full max-w-md text-center">
+        <CardContent>
+          <h1 className="text-2xl font-bold mb-4">Meeting Assistant</h1>
+          <p className="text-muted-foreground">
+            Cool & professional UI powered by Tailwind + shadcn
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/meeting-assistant/apps/web-frontend/src/components/ui/card.tsx
+++ b/meeting-assistant/apps/web-frontend/src/components/ui/card.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("rounded-xl border bg-card text-card-foreground shadow", className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6", className)} {...props} />
+  )
+);
+CardContent.displayName = "CardContent";
+
+export { Card, CardContent };

--- a/meeting-assistant/apps/web-frontend/src/lib/utils.ts
+++ b/meeting-assistant/apps/web-frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/meeting-assistant/apps/web-frontend/src/main.css
+++ b/meeting-assistant/apps/web-frontend/src/main.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/meeting-assistant/apps/web-frontend/src/main.tsx
+++ b/meeting-assistant/apps/web-frontend/src/main.tsx
@@ -1,0 +1,14 @@
+import { StrictMode } from 'react';
+import * as ReactDOM from 'react-dom/client';
+import App from './app/app';
+import './main.css';
+
+const root = ReactDOM.createRoot(
+  document.getElementById('root') as HTMLElement
+);
+
+root.render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/meeting-assistant/apps/web-frontend/src/styles.css
+++ b/meeting-assistant/apps/web-frontend/src/styles.css
@@ -1,0 +1,1 @@
+/* You can add global styles to this file, and also import other style files */

--- a/meeting-assistant/apps/web-frontend/tailwind.config.js
+++ b/meeting-assistant/apps/web-frontend/tailwind.config.js
@@ -1,0 +1,9 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['src/**/*.{ts,tsx}', '../../libs/**/*.tsx'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+

--- a/meeting-assistant/apps/web-frontend/tsconfig.app.json
+++ b/meeting-assistant/apps/web-frontend/tsconfig.app.json
@@ -1,0 +1,31 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.app.tsbuildinfo",
+    "jsx": "react-jsx",
+    "lib": ["dom"],
+    "types": [
+      "node",
+      "@nx/react/typings/cssmodule.d.ts",
+      "@nx/react/typings/image.d.ts",
+      "vite/client"
+    ],
+    "rootDir": "src",
+    "module": "esnext",
+    "moduleResolution": "bundler"
+  },
+  "exclude": [
+    "out-tsc",
+    "dist",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.js",
+    "src/**/*.test.js",
+    "src/**/*.spec.jsx",
+    "src/**/*.test.jsx"
+  ],
+  "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
+}

--- a/meeting-assistant/apps/web-frontend/tsconfig.json
+++ b/meeting-assistant/apps/web-frontend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "files": [],
+  "include": [],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json"
+}

--- a/meeting-assistant/apps/web-frontend/vite.config.ts
+++ b/meeting-assistant/apps/web-frontend/vite.config.ts
@@ -1,0 +1,29 @@
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../node_modules/.vite/web-frontend',
+  server: {
+    port: 4200,
+    host: 'localhost',
+  },
+  preview: {
+    port: 4200,
+    host: 'localhost',
+  },
+  plugins: [react()],
+  // Uncomment this if you are using workers.
+  // worker: {
+  //  plugins: [ nxViteTsPaths() ],
+  // },
+  build: {
+    outDir: './dist',
+    emptyOutDir: true,
+    reportCompressedSize: true,
+    commonjsOptions: {
+      transformMixedEsModules: true,
+    },
+  },
+}));

--- a/meeting-assistant/docker/docker-compose.dev.yml
+++ b/meeting-assistant/docker/docker-compose.dev.yml
@@ -1,0 +1,9 @@
+version: "3.9"
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: dev
+      POSTGRES_PASSWORD: devpass
+      POSTGRES_DB: meetingdb
+    ports: ["5432:5432"]

--- a/meeting-assistant/libs/common-utils/README.md
+++ b/meeting-assistant/libs/common-utils/README.md
@@ -1,0 +1,7 @@
+# common-utils
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build common-utils` to build the library.

--- a/meeting-assistant/libs/common-utils/package.json
+++ b/meeting-assistant/libs/common-utils/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@shared/utils",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/meeting-assistant/libs/common-utils/src/index.ts
+++ b/meeting-assistant/libs/common-utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/common-utils.js';

--- a/meeting-assistant/libs/common-utils/src/lib/common-utils.ts
+++ b/meeting-assistant/libs/common-utils/src/lib/common-utils.ts
@@ -1,0 +1,3 @@
+export function commonUtils(): string {
+  return 'common-utils';
+}

--- a/meeting-assistant/libs/common-utils/tsconfig.json
+++ b/meeting-assistant/libs/common-utils/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/meeting-assistant/libs/common-utils/tsconfig.lib.json
+++ b/meeting-assistant/libs/common-utils/tsconfig.lib.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": []
+}

--- a/meeting-assistant/libs/shared-types/README.md
+++ b/meeting-assistant/libs/shared-types/README.md
@@ -1,0 +1,7 @@
+# shared-types
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build shared-types` to build the library.

--- a/meeting-assistant/libs/shared-types/package.json
+++ b/meeting-assistant/libs/shared-types/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@shared/types",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/meeting-assistant/libs/shared-types/src/index.ts
+++ b/meeting-assistant/libs/shared-types/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/shared-types.js';
+export * from './meeting.entity.js';

--- a/meeting-assistant/libs/shared-types/src/lib/shared-types.ts
+++ b/meeting-assistant/libs/shared-types/src/lib/shared-types.ts
@@ -1,0 +1,3 @@
+export function sharedTypes(): string {
+  return 'shared-types';
+}

--- a/meeting-assistant/libs/shared-types/src/meeting.entity.ts
+++ b/meeting-assistant/libs/shared-types/src/meeting.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('meetings')
+export class Meeting {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ unique: true })
+  externalId!: string;
+
+  @Column()
+  title!: string;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/meeting-assistant/libs/shared-types/tsconfig.json
+++ b/meeting-assistant/libs/shared-types/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/meeting-assistant/libs/shared-types/tsconfig.lib.json
+++ b/meeting-assistant/libs/shared-types/tsconfig.lib.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": []
+}

--- a/meeting-assistant/nx.json
+++ b/meeting-assistant/nx.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "./node_modules/nx/schemas/nx-schema.json",
+  "namedInputs": {
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "production": [
+      "default",
+      "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
+      "!{projectRoot}/tsconfig.spec.json",
+      "!{projectRoot}/src/test-setup.[jt]s"
+    ],
+    "sharedGlobals": []
+  },
+  "plugins": [
+    {
+      "plugin": "@nx/js/typescript",
+      "options": {
+        "typecheck": {
+          "targetName": "typecheck"
+        },
+        "build": {
+          "targetName": "build",
+          "configName": "tsconfig.lib.json",
+          "buildDepsName": "build-deps",
+          "watchDepsName": "watch-deps"
+        }
+      }
+    },
+    {
+      "plugin": "@nx/webpack/plugin",
+      "options": {
+        "buildTargetName": "build",
+        "serveTargetName": "serve",
+        "previewTargetName": "preview",
+        "buildDepsTargetName": "build-deps",
+        "watchDepsTargetName": "watch-deps"
+      }
+    },
+    {
+      "plugin": "@nx/react/router-plugin",
+      "options": {
+        "buildTargetName": "build",
+        "devTargetName": "dev",
+        "startTargetName": "start",
+        "watchDepsTargetName": "watch-deps",
+        "buildDepsTargetName": "build-deps",
+        "typecheckTargetName": "typecheck"
+      }
+    },
+    {
+      "plugin": "@nx/vite/plugin",
+      "options": {
+        "buildTargetName": "build",
+        "testTargetName": "test",
+        "serveTargetName": "serve",
+        "devTargetName": "dev",
+        "previewTargetName": "preview",
+        "serveStaticTargetName": "serve-static",
+        "typecheckTargetName": "typecheck",
+        "buildDepsTargetName": "build-deps",
+        "watchDepsTargetName": "watch-deps"
+      }
+    },
+    {
+      "plugin": "@nx/playwright/plugin",
+      "options": {
+        "targetName": "e2e"
+      }
+    }
+  ],
+  "generators": {
+    "@nx/react": {
+      "application": {
+        "babel": true,
+        "style": "css",
+        "linter": "none",
+        "bundler": "vite"
+      },
+      "component": {
+        "style": "css"
+      },
+      "library": {
+        "style": "css",
+        "linter": "none"
+      }
+    }
+  }
+}

--- a/meeting-assistant/package.json
+++ b/meeting-assistant/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@meeting-assistant/source",
+  "version": "0.0.0",
+  "license": "MIT",
+  "scripts": {
+    "prepare": "husky install"
+  },
+  "private": true,
+  "devDependencies": {
+    "@nestjs/schematics": "^10.2.3",
+    "@nestjs/testing": "^10.4.20",
+    "@nx/devkit": "21.3.11",
+    "@nx/js": "^21.3.11",
+    "@nx/nest": "^21.3.11",
+    "@nx/node": "21.3.11",
+    "@nx/playwright": "21.3.11",
+    "@nx/react": "^21.3.11",
+    "@nx/vite": "21.3.11",
+    "@nx/web": "21.3.11",
+    "@nx/webpack": "21.3.11",
+    "@playwright/test": "^1.36.0",
+    "@swc-node/register": "~1.9.1",
+    "@swc/core": "~1.5.7",
+    "@swc/helpers": "~0.5.11",
+    "@types/node": "^20.0.0",
+    "@types/react": "19.0.0",
+    "@types/react-dom": "19.0.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "@vitest/ui": "^3.0.0",
+    "jiti": "2.4.2",
+    "jsdom": "~22.1.0",
+    "nx": "21.3.11",
+    "prettier": "^2.6.2",
+    "tslib": "^2.3.0",
+    "typescript": "~5.8.2",
+    "vite": "^6.0.0",
+    "vitest": "^3.0.0",
+    "webpack-cli": "^5.1.4",
+    "husky": "^8.0.0"
+  },
+  "workspaces": [
+    "packages/*",
+    "apps/*",
+    "libs/*"
+  ],
+  "dependencies": {
+    "@nestjs/common": "^10.4.20",
+    "@nestjs/config": "^3.3.0",
+    "@nestjs/core": "^10.4.20",
+    "@nestjs/platform-express": "^10.4.20",
+    "@nestjs/typeorm": "^10.0.2",
+    "axios": "^1.6.0",
+    "pg": "^8.16.3",
+    "react": "19.0.0",
+    "react-dom": "19.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.0",
+    "typeorm": "^0.3.25"
+  }
+}

--- a/meeting-assistant/tsconfig.base.json
+++ b/meeting-assistant/tsconfig.base.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "importHelpers": true,
+    "isolatedModules": true,
+    "lib": ["es2022"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022",
+    "customConditions": ["development"]
+  }
+}

--- a/meeting-assistant/tsconfig.json
+++ b/meeting-assistant/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compileOnSave": false,
+  "files": [],
+  "references": [
+    {
+      "path": "./apps/web-frontend"
+    },
+    {
+      "path": "./libs/shared-types"
+    },
+    {
+      "path": "./libs/common-utils"
+    },
+    {
+      "path": "./apps/api-gateway"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold Nx workspace with NestJS API and React frontend
- configure TypeORM Meeting entity and database connection
- add Tailwind + shadcn card UI and health endpoint
- wrap async e2e helpers in try/catch and ignore package-lock
- track PNG and ICO assets with Git LFS and ignore build outputs
- remove default favicon to avoid committing binary assets

## Testing
- `npx nx run-many --target=lint,test --all` (Could not find Nx modules; have you run npm/yarn install?)

------
https://chatgpt.com/codex/tasks/task_e_689416cc0a3083298a5b3bee4dcfdb9d